### PR TITLE
pkgsrc/misc/libreoffice provides no 'soffice' anymore

### DIFF
--- a/Guide/Place/intro.rst
+++ b/Guide/Place/intro.rst
@@ -212,8 +212,8 @@ LibreOfficeをインストールしてみましょう。
  # cd /usr/pkgsrc/misc/libreoffice
  # make package-install
      : 9時間くらいかかります。
- # which soffice
- /usr/pkg/bin/soffice
+ # which loffice
+ /usr/pkg/bin/loffice
 
 依存しているパッケージを調べる
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The recent pkgsrc/misc/libreoffice installs no 'soffice' command.
Please use 'loffice' command instead.